### PR TITLE
Adding comments to most exported types and functions

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 )
 
+// Config holds info required to configure a togo.server.
 type Config struct {
 	HTTPAddr     string `json:"http_addr"`
 	HTTPPort     int    `json:"http_port"`
@@ -14,6 +15,9 @@ type Config struct {
 	LogFilename  string `json:"log_filename"`
 }
 
+// LoadJSONFile attempts to read a specified JSON file by provided filename.
+// It then attempts to unmarshal the JSON data into a Config type object.
+// It returns a populated Config or any errors it encountered during the JSON file load and parse.
 func LoadJSONFile(filename string) (config Config) {
 	var (
 		content []byte

--- a/logger.go
+++ b/logger.go
@@ -11,8 +11,10 @@ import (
 const logPattern = "%s - - [%s] \"%s %s %s\" %d %d %q %q %.4f\n"
 
 var (
+	// Logger is the global logger for the server.
 	Logger = log.New(os.Stdout, "", 0)
-	now    = func() time.Time {
+
+	now = func() time.Time {
 		return time.Now().UTC()
 	}
 )

--- a/resource.go
+++ b/resource.go
@@ -6,12 +6,16 @@ import (
 	"strings"
 )
 
+// Resource holds info required for configuring endpoints and resources for the server.
 type Resource struct {
 	Path    string
 	Method  string
 	Handler http.HandlerFunc
 }
 
+// SanitizedPath trims forward slash characters from the provided string prefix
+// and Path of the resource.
+// Returns the sanitized path string.
 func (r Resource) SanitizedPath(prefix string) string {
 	return fmt.Sprintf(
 		"/%s/%s",

--- a/service.go
+++ b/service.go
@@ -2,6 +2,7 @@ package togo
 
 import "net/http"
 
+// Service is the basic interface that defines what to expect from any service.
 type Service interface {
 	Prefix() string
 	Middleware(http.HandlerFunc) http.HandlerFunc

--- a/togo.go
+++ b/togo.go
@@ -14,6 +14,7 @@ type Togo struct {
 	server      *http.Server
 }
 
+// Init will set up the name, logging, and the HTTP server.
 func Init(appName string, config Config) *Togo {
 	Logger.SetPrefix(fmt.Sprintf("[%s] ", appName))
 
@@ -51,6 +52,7 @@ func (t *Togo) Register(service Service) {
 	t.server.Handler = loggingHandler(mux)
 }
 
+// Run will start the HTTP server for Togo.
 func (t Togo) Run() error {
 	Logger.Printf("Running at %s\n", t.server.Addr)
 	return t.server.ListenAndServe()


### PR DESCRIPTION
All of the `golint` errors from the [report card](https://goreportcard.com/report/github.com/opentogo/togo) have to do with missing comments on export functions, methods, and types.

I've filled in what I could, but there are a few that I'm not 100% how to comment on it, so I will leave that up to you @rogeriozambon !